### PR TITLE
general: Remove pageLabel from ContentChanged event.

### DIFF
--- a/analyzer/src/main/protobuf/io.scalac.newspaper.analyzer/events.proto
+++ b/analyzer/src/main/protobuf/io.scalac.newspaper.analyzer/events.proto
@@ -4,8 +4,7 @@ package io.scalac.newspaper.analyzer;
 
 message ChangeDetected {
     string pageUrl = 1;
-    string pageLabel = 2;
-    string pageContent = 3;
+    string pageContent = 2;
 }
 
 message ContentFetched {

--- a/analyzer/src/main/scala/io/scalac/newspaper/analyzer/AnalyzerRunner.scala
+++ b/analyzer/src/main/scala/io/scalac/newspaper/analyzer/AnalyzerRunner.scala
@@ -28,7 +28,7 @@ object AnalyzerRunner extends App {
       // Do sth with msg.record.value
       println(s"[ANALYZING] ${msg.record.value}")
       val input = msg.record.value
-      val output = ChangeDetected(input.pageUrl, "label", input.pageContent)
+      val output = ChangeDetected(input.pageUrl, input.pageContent)
       val record = new ProducerRecord[Array[Byte], ChangeDetected]("newspaper", output)
       ProducerMessage.Message(record, msg.committableOffset)
     }

--- a/analyzer/src/test/scala/io/scalac/newspaper/analyzer/serializationSpec.scala
+++ b/analyzer/src/test/scala/io/scalac/newspaper/analyzer/serializationSpec.scala
@@ -15,7 +15,7 @@ class serializationSpec extends FlatSpec with Matchers {
   }
 
   "ChangeDetected" should "be serialized and deserialized properly" in {
-    val changeDetected = ChangeDetected("foo", "bar", "baz")
+    val changeDetected = ChangeDetected("foo", "bar")
     val topic = "fnord"
     val serializer = new ChangeDetectedSerializer
     val deserializer = new ChangeDetectedDeserializer

--- a/mailer/src/main/protobuf/io.scalac.newspaper.mailer/events.proto
+++ b/mailer/src/main/protobuf/io.scalac.newspaper.mailer/events.proto
@@ -4,6 +4,5 @@ package io.scalac.newspaper.mailer;
 
 message ChangeDetected {
     string pageUrl = 1;
-    string pageLabel = 2;
-    string pageContent = 3;
+    string pageContent = 2;
 }


### PR DESCRIPTION
As decided in #9.

Additionally, changed `pageContent` ID from `3` to `2`. I know we shouldn't do that, but at this stage of the project's life I don't see much reason for keeping protocol backward-compatible.